### PR TITLE
[SPIRV] Remove dump

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPtrAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPtrAnalysis.cpp
@@ -560,7 +560,6 @@ void SPIRVPtrAnalysis::visitGetElementPtrInst(GetElementPtrInst &I) {
   return;
 }
 void SPIRVPtrAnalysis::visitAddrSpaceCastInst(AddrSpaceCastInst &I) {
-  I.getFunction()->getParent()->dump();
   auto SC = TR->addressSpaceToStorageClass(I.getDestAddressSpace());
   auto *PteTy = getPointerElemTy();
 


### PR DESCRIPTION
`dump` only exists in debug mode, so this fails to link in release mode.